### PR TITLE
Make more inline with current docs

### DIFF
--- a/index.php
+++ b/index.php
@@ -36,20 +36,19 @@ $(document).ready(function() {
             validating: 'glyphicon glyphicon-refresh'
         },
 		submitHandler: function(validator, form, submitButton) {
-                    var chargeAmount = 3000; //amount you want to charge, in cents. 1000 = $10.00, 2000 = $20.00 ...
                     // createToken returns immediately - the supplied callback submits the form if there are no errors
-                    Stripe.createToken({
+                    Stripe.card.createToken({
                         number: $('.card-number').val(),
                         cvc: $('.card-cvc').val(),
                         exp_month: $('.card-expiry-month').val(),
                         exp_year: $('.card-expiry-year').val(),
-						name: $('.card-holder-name').val(),
-						address_line1: $('.address').val(),
-						address_city: $('.city').val(),
-						address_zip: $('.zip').val(),
-						address_state: $('.state').val(),
-						address_country: $('.country').val()
-                    }, chargeAmount, stripeResponseHandler);
+			name: $('.card-holder-name').val(),
+			address_line1: $('.address').val(),
+			address_city: $('.city').val(),
+			address_zip: $('.zip').val(),
+			address_state: $('.state').val(),
+			address_country: $('.country').val()
+                    }, stripeResponseHandler);
                     return false; // submit from callback
         },
         fields: {


### PR DESCRIPTION
Passing an amount to createToken isn't documented anywhere, and using Stripe.card.createToken is more inline with the docs than Stripe.createToken